### PR TITLE
Fix object_id warning, running with Ruby 1.9.2.

### DIFF
--- a/lib/slave.rb
+++ b/lib/slave.rb
@@ -126,7 +126,7 @@ require 'sync'
   #
     class ThreadSafe
 #--{{{
-      instance_methods.each{|m| undef_method m.to_sym unless m[%r/__/]}
+      instance_methods.each{|m| undef_method m.to_sym unless m[%r/__/] || m.to_sym == :object_id }
       def initialize object
         @object = object
         @sync = Sync.new


### PR DESCRIPTION
This patch avoids the following warning when running with 1.9.2:
slave-1.2.1/lib/slave.rb:129: warning: undefining `object_id' may cause serious problems.
